### PR TITLE
crt-pi-curvature: add compatibility for precision, fix a GLSL error

### DIFF
--- a/shaders/crt-pi-curvature-vertical.glsl
+++ b/shaders/crt-pi-curvature-vertical.glsl
@@ -17,15 +17,23 @@
 // MASK_TYPE: 0 = none, 1 = green/magenta, 2 = trinitron(ish)
 #define MASK_TYPE 1
 
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+precision mediump float;
+#else
+#define COMPAT_PRECISION
+#endif
+
 #ifdef PARAMETER_UNIFORM
-uniform float CURVATURE_X;
-uniform float CURVATURE_Y;
-uniform float MASK_BRIGHTNESS;
-uniform float SCANLINE_WEIGHT;
-uniform float SCANLINE_GAP_BRIGHTNESS;
-uniform float BLOOM_FACTOR;
-uniform float INPUT_GAMMA;
-uniform float OUTPUT_GAMMA;
+uniform COMPAT_PRECISION float CURVATURE_X;
+uniform COMPAT_PRECISION float CURVATURE_Y;
+uniform COMPAT_PRECISION float MASK_BRIGHTNESS;
+uniform COMPAT_PRECISION float SCANLINE_WEIGHT;
+uniform COMPAT_PRECISION float SCANLINE_GAP_BRIGHTNESS;
+uniform COMPAT_PRECISION float BLOOM_FACTOR;
+uniform COMPAT_PRECISION float INPUT_GAMMA;
+uniform COMPAT_PRECISION float OUTPUT_GAMMA;
 #else
 #define CURVATURE_X 0.10
 #define CURVATURE_Y 0.25
@@ -107,12 +115,12 @@ void main()
 uniform sampler2D Texture;
 
 #if defined(CURVATURE)
-vec2 CURVATURE_DISTORTION = vec2(CURVATURE_X, CURVATURE_Y);
-// Barrel distortion shrinks the display area a bit, this will allow us to counteract that.
-vec2 barrelScale = 1.0 - (0.23 * CURVATURE_DISTORTION);
-
 vec2 Distort(vec2 coord)
 {
+	vec2 CURVATURE_DISTORTION = vec2(CURVATURE_X, CURVATURE_Y);
+	// Barrel distortion shrinks the display area a bit, this will allow us to counteract that.
+	vec2 barrelScale = 1.0 - (0.23 * CURVATURE_DISTORTION);
+
 	coord *= screenScale;
 	coord -= vec2(0.5);
 	float rsq = coord.x * coord.x + coord.y * coord.y;

--- a/shaders/crt-pi-curvature.glsl
+++ b/shaders/crt-pi-curvature.glsl
@@ -17,15 +17,23 @@
 // MASK_TYPE: 0 = none, 1 = green/magenta, 2 = trinitron(ish)
 #define MASK_TYPE 1
 
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+precision mediump float;
+#else
+#define COMPAT_PRECISION
+#endif
+
 #ifdef PARAMETER_UNIFORM
-uniform float CURVATURE_X;
-uniform float CURVATURE_Y;
-uniform float MASK_BRIGHTNESS;
-uniform float SCANLINE_WEIGHT;
-uniform float SCANLINE_GAP_BRIGHTNESS;
-uniform float BLOOM_FACTOR;
-uniform float INPUT_GAMMA;
-uniform float OUTPUT_GAMMA;
+uniform COMPAT_PRECISION float CURVATURE_X;
+uniform COMPAT_PRECISION float CURVATURE_Y;
+uniform COMPAT_PRECISION float MASK_BRIGHTNESS;
+uniform COMPAT_PRECISION float SCANLINE_WEIGHT;
+uniform COMPAT_PRECISION float SCANLINE_GAP_BRIGHTNESS;
+uniform COMPAT_PRECISION float BLOOM_FACTOR;
+uniform COMPAT_PRECISION float INPUT_GAMMA;
+uniform COMPAT_PRECISION float OUTPUT_GAMMA;
 #else
 #define CURVATURE_X 0.10
 #define CURVATURE_Y 0.25
@@ -105,12 +113,12 @@ void main()
 uniform sampler2D Texture;
 
 #if defined(CURVATURE)
-vec2 CURVATURE_DISTORTION = vec2(CURVATURE_X, CURVATURE_Y);
-// Barrel distortion shrinks the display area a bit, this will allow us to counteract that.
-vec2 barrelScale = 1.0 - (0.23 * CURVATURE_DISTORTION);
-
 vec2 Distort(vec2 coord)
 {
+	vec2 CURVATURE_DISTORTION = vec2(CURVATURE_X, CURVATURE_Y);
+	// Barrel distortion shrinks the display area a bit, this will allow us to counteract that.
+	vec2 barrelScale = 1.0 - (0.23 * CURVATURE_DISTORTION);
+
 	coord *= screenScale;
 	coord -= vec2(0.5);
 	float rsq = coord.x * coord.x + coord.y * coord.y;


### PR DESCRIPTION
The 'crt-pi-curvature' shaders don't load on a PI4, which uses a newer GLSL
Added compatibility settings - similar to the `crt-pi` shaders - and also the fix from https://github.com/libretro/glsl-shaders/commit/ee28398877221bc5a893e1377bb290c76014fb76#diff-a15fc9427b21956807311e7e462ecf2c.